### PR TITLE
Use a config file for presets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !Pipfile
 !Pipfile.lock
 !entrypoint.sh
+!config.json
 # !LICENSE
 # !README.md
 # !THIRD_PARTY_NOTICE.md

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -22,7 +22,7 @@ action "Build" {
 action "Docker Run" {
   needs = ["Build"]
   uses = "actions/docker/cli@master"
-  args = "run -t httpie-action --ignore-stdin --pretty=all --default-scheme=https --print=hb api.github.com/zen"
+  args = "run -t httpie-action api.github.com/zen"
 }
 
 action "Docker Tag" {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM python:3-slim-stretch
 
-WORKDIR /
-
-COPY "entrypoint.sh" "Pipfile" "Pipfile.lock" /
-
 LABEL name="HTTPie CLI"
 LABEL version="1.0.0"
 LABEL repository="http://github.com/swinton/httpie-action"
@@ -15,10 +11,17 @@ LABEL com.github.actions.description="Wraps the HTTPie CLI to enable human-frien
 LABEL com.github.actions.icon="upload-cloud"
 LABEL com.github.actions.color="gray-dark"
 
+WORKDIR /
+
+COPY "entrypoint.sh" "Pipfile" "Pipfile.lock" /
+COPY "config.json" /.httpie/
+
 RUN apt-get update && \
   pip install --upgrade pip && \
   pip install --upgrade pipenv && \
   pipenv install
+
+ENV HTTPIE_CONFIG_DIR /.httpie
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ workflow "Call external API" {
 
 action "Call httpbin" {
   uses = "swinton/httpie-action@master"
-  args = ["--ignore-stdin", "https://httpbin.org/anything", "foo=bar"]
+  args = ["httpbin.org/anything", "foo=bar"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # httpie-action
 
-GitHub Actions compatible version of [HTTPie](https://github.com/jakubroztocil/httpie).
+> Human-friendly interactions with third-party web services with **GitHub Actions**.
+
+[**GitHub Actions**](https://developer.github.com/actions/) compatible version of [**HTTPie**](https://github.com/jakubroztocil/httpie).
 
 ## Usage
 
@@ -17,6 +19,15 @@ action "Call httpbin" {
   args = ["httpbin.org/anything", "foo=bar"]
 }
 ```
+
+## Presets
+
+Some [HTTPie presets](https://github.com/jakubroztocil/httpie/blob/358342d1c915d6462a080a77aefbb20166d0bd5d/README.rst#config) are applied by default by the included [`config.json`](config.json), that make sense in the context of GitHub Actions, namely:
+
+1. [`--check-status`](https://github.com/jakubroztocil/httpie/blob/358342d1c915d6462a080a77aefbb20166d0bd5d/README.rst#scripting): Causes a workflow to exit if the HTTP status is one of `3xx`, `4xx`, or `5xx`
+1. [`--ignore-stdin`](https://github.com/jakubroztocil/httpie/blob/358342d1c915d6462a080a77aefbb20166d0bd5d/README.rst#best-practices): Disables HTTPie's default behaviour of automatically reading STDIN, typically not desirable during non-interactive invocations
+1. [`--default-scheme=https`](https://github.com/jakubroztocil/httpie/blob/358342d1c915d6462a080a77aefbb20166d0bd5d/README.rst#custom-default-scheme): Assumes `https://` is the default prefix for URLs, so you can just say (for example) `api.github.com/zen` as opposed to `https://api.github.com/zen`
+1. [`--print=hb`](https://github.com/jakubroztocil/httpie/blob/358342d1c915d6462a080a77aefbb20166d0bd5d/README.rst#output-options): Prints both response headers _and_ response body in the output
 
 ## More info
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # httpie-action
 
-> Human-friendly interactions with third-party web services with **GitHub Actions**.
+> Human-friendly interactions with third-party web services through **GitHub Actions** :zap:
 
-[**GitHub Actions**](https://developer.github.com/actions/) compatible version of [**HTTPie**](https://github.com/jakubroztocil/httpie).
+A [**GitHub Actions**](https://developer.github.com/actions/)-compatible version of [**HTTPie**](https://github.com/jakubroztocil/httpie), allowing you to interact with any third-party service that exposes an API over HTTP in your [development workflow](https://developer.github.com/actions/creating-workflows/).
 
-## Usage
+## Simple example
 
-Use as part of a GitHub Action like so:
+To call `httpbin.org` on every `push` to the repo:
 
 ```hcl
 workflow "Call external API" {

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+  "default_options": [
+    "--ignore-stdin",
+    "--print=hb",
+    "--default-scheme=https",
+    "--pretty=all"
+  ]
+}

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "--ignore-stdin",
     "--print=hb",
     "--default-scheme=https",
-    "--pretty=format"
+    "--pretty=format",
+    "--check-status"
   ]
 }

--- a/config.json
+++ b/config.json
@@ -3,6 +3,6 @@
     "--ignore-stdin",
     "--print=hb",
     "--default-scheme=https",
-    "--pretty=all"
+    "--pretty=format"
   ]
 }


### PR DESCRIPTION
Sets up a few presets by applying [httpie's simple JSON config file](https://github.com/jakubroztocil/httpie/blob/358342d1c915d6462a080a77aefbb20166d0bd5d/README.rst#config):

1. `--ignore-stdin`
1. `--print=hb`
1. `--default-scheme=https`
1. `--pretty=all`
